### PR TITLE
Generated IDE projects should support sub-folders

### DIFF
--- a/esl/CMakeLists.txt
+++ b/esl/CMakeLists.txt
@@ -39,3 +39,6 @@ target_compile_definitions(esl
       _DEBUG
     >
 )
+
+get_target_property(esl_FILES esl SOURCES)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${esl_FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,6 @@ else()
 endif()
 
 get_target_property(test_FILES esl_test SOURCES)
-source_group("esl_test" FILES ${test_FILES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test_FILES})
 
 add_test(NAME tests COMMAND esl_test)


### PR DESCRIPTION
Keep source folder structure in generated IDE project files.