### PR TITLE
Fix compile error when using string_view as split delimiter

### DIFF
--- a/build.py
+++ b/build.py
@@ -13,9 +13,24 @@ import platform
 import shutil
 import subprocess
 
-from distutils.util import strtobool
-
 OS_WIN = 'Windows'
+
+
+# `distuils` is deprecated and will be removed since 3.12. Let's retain the
+# function.
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 def default_generator():

--- a/esl/strings.h
+++ b/esl/strings.h
@@ -137,6 +137,11 @@ public:
         assert(!delimiter_.empty());
     }
 
+    template<typename StringViewLike,
+             std::enable_if_t<std::is_same_v<StringViewLike, std::string_view>, int> = 0>
+    explicit by_string(StringViewLike delim)
+        : by_string(std::string{delim}) {}
+
     std::size_t find(std::string_view text, std::size_t pos) const noexcept {
         return delimiter_.size() == 1 ? text.find(delimiter_[0], pos)
                                       : text.find(delimiter_, pos);
@@ -174,6 +179,11 @@ public:
         : delimiters_(std::move(delims)) {
         assert(!delimiters_.empty());
     }
+
+    template<typename StringViewLike,
+             std::enable_if_t<std::is_same_v<StringViewLike, std::string_view>, int> = 0>
+    explicit by_any_char(StringViewLike delim)
+        : by_any_char(std::string{delim}) {}
 
     std::size_t find(std::string_view text, std::size_t pos) const noexcept {
         return delimiters_.size() == 1 ? text.find_first_of(delimiters_[0], pos)


### PR DESCRIPTION
Delimiter `by_string` and `by_any_char` already each has a constructor taking `std::string` and we need explicit conversion/construction from `std::string_view` to `std::string`.

However, if we added the overload taking `std::string_view`, to avoid overload resolution ambiguity for c-style null-terminated string, a SFINAE must be introduced.

Also get rid of deprecated `distutils` in `build.py`