### PR TITLE
Allow move construction and throw from ESL_ON_SCOPE_SUCCESS

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,


### PR DESCRIPTION
1. Allow move construction on scope_guard
2. Allow guard function throws from `ESL_ON_SCOPE_SUCCESS`
3. Add tests for above changes
4. Since tidy rule `cppcoreguidelines-non-private-member-variables-in-classes` is a synonym of `misc-non-private-member-variables-in-classes` we can exclude the former rule from our tidy rules, in case we need to NOLINT on these rules both