### PR TITLE
Add by_length for string split

### DIFF
--- a/esl/strings.h
+++ b/esl/strings.h
@@ -164,7 +164,7 @@ public:
         return text.find(ch_, pos);
     }
 
-    std::size_t size() const noexcept { // NOLINT(readability-convert-member-functions-to-static)
+    static std::size_t size() noexcept {
         return 1;
     }
 
@@ -190,12 +190,33 @@ public:
                                        : text.find_first_of(delimiters_, pos);
     }
 
-    std::size_t size() const noexcept { // NOLINT(readability-convert-member-functions-to-static)
+    static std::size_t size() noexcept {
         return 1;
     }
 
 private:
     std::string delimiters_;
+};
+
+// The behavior is undefined if given `len` is 0.
+class by_length {
+public:
+    explicit by_length(std::size_t len)
+        : limit_len_(len) {
+        assert(len > 0);
+    }
+
+    std::size_t find(std::string_view text, std::size_t pos) const noexcept {
+        const auto next_pos = pos + limit_len_;
+        return next_pos < text.size() ? next_pos : std::string_view::npos;
+    }
+
+    static std::size_t size() noexcept {
+        return 0;
+    }
+
+private:
+    std::size_t limit_len_;
 };
 
 struct allow_any {

--- a/tests/strings_split_test.cpp
+++ b/tests/strings_split_test.cpp
@@ -343,6 +343,38 @@ TEST_CASE("delimiter by_any_char") {
     }
 }
 
+TEST_CASE("delimiter by_length") {
+    SUBCASE("split by length into multiple group") {
+        auto v = strings::split("12345", strings::by_length(2)).to<std::vector<std::string>>();
+        REQUIRE_EQ(v.size(), 3);
+        CHECK_EQ(v[0], "12");
+        CHECK_EQ(v[1], "34");
+        CHECK_EQ(v[2], "5");
+    }
+
+    SUBCASE("length is exactly same as the string size") {
+        auto v = strings::split("12345", strings::by_length(5)).to<std::vector<std::string>>();
+        REQUIRE_EQ(v.size(), 1);
+        CHECK_EQ(v[0], "12345");
+    }
+
+    SUBCASE("length is greater than string size") {
+        auto v = strings::split("12345", strings::by_length(6)).to<std::vector<std::string>>();
+        REQUIRE_EQ(v.size(), 1);
+        CHECK_EQ(v[0], "12345");
+    }
+
+    SUBCASE("one by one") {
+        auto v = strings::split("12345", strings::by_length(1)).to<std::vector<std::string>>();
+        REQUIRE_EQ(v.size(), 5);
+        CHECK_EQ(v[0], "1");
+        CHECK_EQ(v[1], "2");
+        CHECK_EQ(v[2], "3");
+        CHECK_EQ(v[3], "4");
+        CHECK_EQ(v[4], "5");
+    }
+}
+
 TEST_CASE("split functions") {
     SUBCASE("normal usages") {
         SUBCASE("auto deduce as by_char delimiter") {


### PR DESCRIPTION
With `by_length` delimiter, we can split a string at every  _n_ characters.