### PR TITLE
Put split delimiter type mapping into detail and remove header guard

### DIFF
--- a/esl/byteswap.h
+++ b/esl/byteswap.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_BYTESWAP_H_
-#define ESL_BYTESWAP_H_
-
 #include <cstdint>
 
 #if defined(_WIN32)
@@ -74,5 +71,3 @@ inline std::uint64_t byteswap(std::uint64_t n) noexcept {
 #endif
 
 } // namespace esl
-
-#endif // ESL_BYTESWAP_H_

--- a/esl/detail/files.h
+++ b/esl/detail/files.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_DETAIL_FILES_H_
-#define ESL_DETAIL_FILES_H_
-
 #include <cstdint>
 #include <cstdio>
 
@@ -43,5 +40,3 @@ inline std::size_t get_file_size(std::FILE* fp) {
 }
 
 } // namespace esl::detail
-
-#endif // ESL_DETAIL_FILES_H_

--- a/esl/detail/secure_crt.h
+++ b/esl/detail/secure_crt.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_DETAIL_SECURE_CRT_H_
-#define ESL_DETAIL_SECURE_CRT_H_
-
 #include <cstdio>
 #include <string>
 
@@ -26,5 +23,3 @@ inline unique_file fopen(const std::string& filepath, const char* mode) {
 }
 
 } // namespace esl::detail
-
-#endif // ESL_DETAIL_SECURE_CRT_H_

--- a/esl/detail/strings_join.h
+++ b/esl/detail/strings_join.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_DETAIL_STRINGS_JOIN_H_
-#define ESL_DETAIL_STRINGS_JOIN_H_
-
 #include <cassert>
 #include <iterator>
 #include <string>
@@ -97,5 +94,3 @@ join_impl(Iterator first, Iterator last, std::string_view sep, std::string& out)
 }
 
 } // namespace esl::strings::detail
-
-#endif // ESL_DETAIL_STRINGS_JOIN_H_

--- a/esl/detail/strings_match.h
+++ b/esl/detail/strings_match.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#ifndef ESL_DETAIL_STRINGS_MATCH_H_
-#define ESL_DETAIL_STRINGS_MATCH_H_
+#include <cassert>
+#include <string_view>
 
 namespace esl::strings::detail {
 
@@ -34,5 +34,3 @@ constexpr int compare_n_ignore_ascii_case(std::string_view s1,
 }
 
 } // namespace esl::strings::detail
-
-#endif // ESL_DETAIL_STRINGS_MATCH_H_

--- a/esl/detail/strings_split.h
+++ b/esl/detail/strings_split.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_DETAIL_STRINGS_SPLIT_H_
-#define ESL_DETAIL_STRINGS_SPLIT_H_
-
 #include <cassert>
 #include <cstddef>
 #include <iterator>
@@ -16,7 +13,12 @@
 #include <type_traits>
 #include <vector>
 
-namespace esl::strings::detail {
+namespace esl::strings {
+
+class by_char;
+class by_string;
+
+namespace detail {
 
 template<typename Delimiter, typename Predicate>
 class split_iterator {
@@ -273,6 +275,35 @@ private:
     Predicate predicate_;
 };
 
-} // namespace esl::strings::detail
+template<typename Delimiter>
+struct select_delimiter {
+    using type = Delimiter;
+};
 
-#endif // ESL_DETAIL_STRINGS_SPLIT_H_
+template<>
+struct select_delimiter<char> {
+    using type = by_char;
+};
+
+template<>
+struct select_delimiter<char*> {
+    using type = by_string;
+};
+
+template<>
+struct select_delimiter<const char*> {
+    using type = by_string;
+};
+
+template<>
+struct select_delimiter<std::string_view> {
+    using type = by_string;
+};
+
+template<>
+struct select_delimiter<std::string> {
+    using type = by_string;
+};
+
+} // namespace detail
+} // namespace esl::strings

--- a/esl/file_util.h
+++ b/esl/file_util.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_FILE_UTIL_H_
-#define ESL_FILE_UTIL_H_
-
 #include <cassert>
 #include <cerrno>
 #include <cstdint>
@@ -107,5 +104,3 @@ inline void write_to_file(const std::string& path, std::string_view content) {
 }
 
 } // namespace esl
-
-#endif // ESL_FILE_UTIL_H_

--- a/esl/macros.h
+++ b/esl/macros.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_MACROS_H_
-#define ESL_MACROS_H_
-
 #if !defined(__COUNTER__)
 #error "Requires __COUNTER__"
 #endif
@@ -14,5 +11,3 @@
 #define ESL_CONCAT_IMPL(a, b)  a##b
 #define ESL_CONCAT(a, b)       ESL_CONCAT_IMPL(a, b)
 #define ESL_ANONYMOUS_VAR(tag) ESL_CONCAT(ESL_CONCAT(ESL_CONCAT(tag, __LINE__), _), __COUNTER__)
-
-#endif // ESL_MACROS_H_

--- a/esl/scope_guard.h
+++ b/esl/scope_guard.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_SCOPE_GUARD_H_
-#define ESL_SCOPE_GUARD_H_
-
 #include <cstddef>
 #include <cstdio>
 #include <exception>
@@ -230,5 +227,3 @@ template<typename F>
             ::esl::detail::scope_guard_on_success{} + [&]()
 
 // NOLINTEND(bugprone-macro-parentheses)
-
-#endif // ESL_SCOPE_GUARD_H_

--- a/esl/strings.h
+++ b/esl/strings.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_STRINGS_H_
-#define ESL_STRINGS_H_
-
 #include <cassert>
 #include <string>
 #include <string_view>
@@ -18,6 +15,10 @@
 #include "esl/detail/strings_split.h"
 
 namespace esl::strings {
+
+//
+// match
+//
 
 constexpr bool equals_ignore_ascii_case(std::string_view s1, std::string_view s2) noexcept {
     return s1.size() == s2.size() && detail::compare_n_ignore_ascii_case(s1, s2, s1.size()) == 0;
@@ -43,6 +44,10 @@ constexpr bool ends_with_ignore_ascii_case(std::string_view str,
     return str.size() >= suffix.size() &&
            equals_ignore_ascii_case(str.substr(str.size() - suffix.size()), suffix);
 }
+
+//
+// join
+//
 
 template<typename Iterator>
 void join(Iterator first, Iterator last, std::string_view sep, std::string& out) {
@@ -128,6 +133,10 @@ std::string join(std::initializer_list<T> il, std::string_view sep, Appender&& a
     join(il, sep, out, std::forward<Appender>(ap));
     return out;
 }
+
+//
+// split
+//
 
 // The behavior is undefined if given `delim` is empty.
 class by_string {
@@ -231,40 +240,6 @@ struct skip_empty {
     }
 };
 
-namespace detail {
-
-template<typename Delimiter>
-struct select_delimiter {
-    using type = Delimiter;
-};
-
-template<>
-struct select_delimiter<char> {
-    using type = by_char;
-};
-
-template<>
-struct select_delimiter<char*> {
-    using type = by_string;
-};
-
-template<>
-struct select_delimiter<const char*> {
-    using type = by_string;
-};
-
-template<>
-struct select_delimiter<std::string_view> {
-    using type = by_string;
-};
-
-template<>
-struct select_delimiter<std::string> {
-    using type = by_string;
-};
-
-} // namespace detail
-
 template<typename Delimiter>
 auto split(std::string_view text, Delimiter delim) {
     using delimiter_t = typename detail::select_delimiter<Delimiter>::type;
@@ -301,6 +276,10 @@ auto split(StringType&& text, Delimiter delim, Predicate predicate) {
     return detail::split_view<std::string, delimiter_t, Predicate>(
             static_cast<std::string&&>(text), delimiter_t(delim), predicate);
 }
+
+//
+// trim
+//
 
 [[nodiscard]] constexpr std::string_view trim_prefix(std::string_view str,
                                                      std::string_view prefix) noexcept {
@@ -368,5 +347,3 @@ inline void trim_inplace(std::string& str, std::string_view chars) {
 }
 
 } // namespace esl::strings
-
-#endif // ESL_STRINGS_H_

--- a/esl/unique_handle.h
+++ b/esl/unique_handle.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_UNIQUE_HANDLE_H_
-#define ESL_UNIQUE_HANDLE_H_
-
 #include <cstdio>
 #include <memory>
 
@@ -143,5 +140,3 @@ inline unique_file wrap_unique_file(std::FILE* fp) {
 }
 
 } // namespace esl
-
-#endif // ESL_UNIQUE_HANDLE_H_

--- a/tests/stringification.h
+++ b/tests/stringification.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_TESTS_STRINGIFICATION_H_
-#define ESL_TESTS_STRINGIFICATION_H_
-
 #include <deque>
 #include <list>
 #include <map>
@@ -15,6 +12,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#include "doctest/doctest.h"
 
 namespace doctest {
 
@@ -124,5 +123,3 @@ struct StringMaker<std::unordered_map<K, V>> {
 };
 
 } // namespace doctest
-
-#endif // ESL_TESTS_STRINGIFICATION_H_

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#ifndef ESL_TESTS_TEST_UTIL_H_
-#define ESL_TESTS_TEST_UTIL_H_
-
 #include <chrono>
 #include <filesystem>
 #include <random>
@@ -26,5 +23,3 @@ inline std::string new_test_filepath() {
 }
 
 } // namespace tests
-
-#endif // ESL_TESTS_TEST_UTIL_H_


### PR DESCRIPTION
- delimiter type mapping is details of string split and should be hidden from the public interface file
- its enough to use `#pragma once` since almost mainstream compilers support it