### PR TITLE
Fix gcc build and tidy issues after upgrade to v17

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,18 +15,23 @@ Checks: >
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-noexcept-destructor,
+  -cppcoreguidelines-noexcept-move-operations,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-vararg,
+  -misc-include-cleaner,
   -misc-no-recursion,
   -modernize-avoid-c-arrays,
   -modernize-return-braced-init-list,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -performance-no-int-to-ptr,
+  -performance-noexcept-destructor,
+  -performance-noexcept-move-constructor,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-named-parameter,
@@ -38,6 +43,8 @@ HeaderFilterRegex: '(esl|tests)\/.*\.h$'
 
 CheckOptions:
   - key: cppcoreguidelines-macro-usage.CheckCapsOnly
+    value: 1
+  - key: cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreNonDeducedTemplateTypes
     value: 1
   - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value: 1

--- a/esl/detail/strings_join.h
+++ b/esl/detail/strings_join.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstddef>
 #include <iterator>
 #include <string>
 #include <string_view>
@@ -37,10 +38,11 @@ template<typename Iterator, typename Appender>
 void join_append(Iterator first, Iterator last, std::string_view sep, std::string& out,
                  Appender&& appender) {
     assert(first != last);
-    appender(*first, out);
+    auto&& ap = std::forward<Appender>(appender);
+    ap(*first, out);
     for (auto it = ++first; it != last; ++it) {
         out.append(sep);
-        appender(*it, out);
+        ap(*it, out);
     }
 }
 

--- a/esl/scope_guard.h
+++ b/esl/scope_guard.h
@@ -98,7 +98,7 @@ public:
 
 private:
     template<typename F>
-    scope_guard(F&& fn, scope_guard_base&& failsafe)
+    scope_guard(F&& fn, scope_guard_base&& failsafe) // NOLINT(*-rvalue-reference-param-not-moved)
         : scope_guard_base(),
           guard_fn_(std::forward<F>(fn)) {
         failsafe.dismiss();

--- a/esl/strings.h
+++ b/esl/strings.h
@@ -261,7 +261,8 @@ auto split(std::string_view text, Delimiter delim, Predicate predicate) {
 template<typename Delimiter,
          typename StringType,
          std::enable_if_t<std::is_same_v<std::remove_cv_t<StringType>, std::string>, int> = 0>
-auto split(StringType&& text, Delimiter delim) {
+auto split(StringType&& text, // NOLINT(cppcoreguidelines-missing-std-forward)
+           Delimiter delim) {
     using delimiter_t = typename detail::select_delimiter<Delimiter>::type;
     return detail::split_view<std::string, delimiter_t, allow_any>(
             static_cast<std::string&&>(text), delimiter_t(delim), allow_any{});
@@ -271,7 +272,9 @@ template<typename Delimiter,
          typename StringType,
          typename Predicate,
          std::enable_if_t<std::is_same_v<std::remove_cv_t<StringType>, std::string>, int> = 0>
-auto split(StringType&& text, Delimiter delim, Predicate predicate) {
+auto split(StringType&& text, // NOLINT(cppcoreguidelines-missing-std-forward)
+           Delimiter delim,
+           Predicate predicate) {
     using delimiter_t = typename detail::select_delimiter<Delimiter>::type;
     return detail::split_view<std::string, delimiter_t, Predicate>(
             static_cast<std::string&&>(text), delimiter_t(delim), predicate);

--- a/tests/file_util_test.cpp
+++ b/tests/file_util_test.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
 #include <system_error>
 
 #include "doctest/doctest.h"

--- a/tests/scope_guard_test.cpp
+++ b/tests/scope_guard_test.cpp
@@ -3,7 +3,11 @@
 // in the LICENSE file.
 
 #include <functional>
+#include <iostream>
 #include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "doctest/doctest.h"
@@ -44,7 +48,11 @@ struct throw_on_copy_invoker {
           throw_after_copied(allow_copied_count) {}
 
     // Force scope_guard copying this invoker.
-    throw_on_copy_invoker(throw_on_copy_invoker&& other) noexcept(false) = default;
+    // Use `= default` will fail with GCC
+    throw_on_copy_invoker(throw_on_copy_invoker&& other) noexcept(false)
+        : invoked_counter(other.invoked_counter),
+          throw_after_copied(other.throw_after_copied),
+          copied_counter(other.copied_counter) {}
 
     throw_on_copy_invoker(const throw_on_copy_invoker& other)
         : invoked_counter(other.invoked_counter),
@@ -242,6 +250,7 @@ TEST_CASE("handy macros") {
                 CHECK_EQ(i, 0);
                 throw std::runtime_error("vala");
             } catch (...) {
+                std::cerr << __FILE__ << ":" << __LINE__ << " catched for scope exit";
             }
             CHECK_EQ(i, 1);
         }
@@ -266,6 +275,7 @@ TEST_CASE("handy macros") {
                 };
                 throw std::runtime_error("vala");
             } catch (...) {
+                std::cerr << __FILE__ << ":" << __LINE__ << " catched for scope faile";
             }
             CHECK(guard_executed);
         }
@@ -290,6 +300,7 @@ TEST_CASE("handy macros") {
                 };
                 throw std::runtime_error("omg");
             } catch (...) {
+                std::cerr << __FILE__ << ":" << __LINE__ << " catched for scope sucess";
             }
             CHECK_FALSE(guard_executed);
         }

--- a/tests/strings_join_test.cpp
+++ b/tests/strings_join_test.cpp
@@ -2,18 +2,22 @@
 // This file is subject to the terms of license that can be found
 // in the LICENSE file.
 
+#include <cstddef>
 #include <deque>
 #include <forward_list>
 #include <iterator>
 #include <list>
 #include <set>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "doctest/doctest.h"
 
+#include "esl/detail/strings_join.h"
 #include "esl/strings.h"
 
 namespace strings = esl::strings;

--- a/tests/strings_match_test.cpp
+++ b/tests/strings_match_test.cpp
@@ -7,6 +7,7 @@
 
 #include "doctest/doctest.h"
 
+#include "esl/detail/strings_match.h"
 #include "esl/strings.h"
 
 namespace strings = esl::strings;

--- a/tests/strings_split_test.cpp
+++ b/tests/strings_split_test.cpp
@@ -2,8 +2,12 @@
 // This file is subject to the terms of license that can be found
 // in the LICENSE file.
 
+#include <array>
+#include <cstddef>
 #include <deque>
 #include <forward_list>
+#include <initializer_list>
+#include <iterator>
 #include <list>
 #include <map>
 #include <queue>
@@ -11,12 +15,15 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "doctest/doctest.h"
 
+#include "esl/detail/strings_split.h"
 #include "esl/strings.h"
 #include "tests/stringification.h"
 

--- a/tests/strings_trim_test.cpp
+++ b/tests/strings_trim_test.cpp
@@ -8,7 +8,6 @@
 #include "doctest/doctest.h"
 
 #include "esl/strings.h"
-#include "tests/stringification.h"
 
 namespace strings = esl::strings;
 

--- a/tests/unique_handle_test.cpp
+++ b/tests/unique_handle_test.cpp
@@ -2,7 +2,10 @@
 // This file is subject to the terms of license that can be found
 // in the LICENSE file.
 
-#include <tuple>
+#include <cerrno>
+#include <cstdio>
+#include <memory>
+#include <string>
 #include <type_traits>
 
 #if !defined(_WIN32)


### PR DESCRIPTION
1. A move constructor with `noexcept(false)` but `=default` will still be treated as nothrow-move-constructible in gcc-11 (i.e. default gcc compiler on Ubuntu 22.04), so replace `=default` with explicit ctor body to address the issue.
2. After upgrading clang-tools to v17 there are new tidy checks failed and got fixed
3. Added/deleted headers as suggested by include-what-you-use


