### PR TITLE
Update .clang-format and pre-commit hook

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 ---
-# Compliant to clang-foramt 11
+# Compliant to clang-foramt 17
 Language: Cpp
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
@@ -12,6 +12,11 @@ AlwaysBreakTemplateDeclarations: Yes
 ColumnLimit: 0
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 8
+BracedInitializerIndentWidth: 4
+BreakAfterAttributes: Leave
+BreakBeforeConceptDeclarations: Always
+EmptyLineAfterAccessModifier: Never
+IfMacros: ['IF']
 IncludeCategories:
   - Regex: '^<.*'
     Priority: 1
@@ -21,7 +26,15 @@ IncludeCategories:
     Priority: 3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentWidth: 4
+IndentRequiresClause: false
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LineEnding: LF
 PointerAlignment: Left
+QualifierAlignment: Custom
+QualifierOrder: ['inline', 'static', 'friend', 'constexpr', 'const', 'volatile', 'type']
+RequiresClausePosition: OwnLine
+ShortNamespaceLines: 0
 SpaceAfterTemplateKeyword: false
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 ...

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,18 +1,49 @@
 #!/usr/bin/env bash
 
-echo -e "Running clang-format-diff...\n"
+function run_clang_format_diff() {
+    echo "Running clang-format-diff..."
+    command -v "clang-format-diff.py" > /dev/null 2>&1 ||
+    if [ "$?" ]; then
+        echo "clang-format-diff.py not found, skip!"
+        echo "Please setup clang-format-diff.py"
+        exit 0
+    fi
 
-fmt_diff=$(git diff --no-ext -U0 --no-color --relative --cached | clang-format-diff.py -p1)
+    fmt_diff=$(git diff --no-ext -U0 --no-color --relative --cached | clang-format-diff.py -p1)
 
-colorize_diff='
-    /^+/ { printf "\033[1;32m" }
-    /^-/ { printf "\033[1;31m" }
-    // { print $0 "\033[0m"; }'
+    colorize_diff='
+        /^+/ { printf "\033[1;32m" }
+        /^-/ { printf "\033[1;31m" }
+        // { print $0 "\033[0m"; }'
 
-if [ -n "$fmt_diff" ]; then
-    echo "$fmt_diff" | awk "$colorize_diff"
-    echo -e "\nPlease re-format above files before commit"
-    exit 1
-fi
+    if [ -n "${fmt_diff}" ]; then
+        echo "${fmt_diff}" | awk "${colorize_diff}"
+        echo -e "\nPlease re-format above files before commit"
+        exit 1
+    fi
 
-echo "clang-format-diff passed"
+    echo "clang-format-diff passed"
+}
+
+function run_line_length_check() {
+    echo "Running line-length check..."
+    command -v "cpplint" > /dev/null 2>&1 ||
+    if [ "$?" ]; then
+        echo "cpplint not found, skip!"
+        echo "please install cpplint"
+        exit 0
+    fi
+
+    changed_files=$(git diff --cached --name-only | grep -iE '\.(cpp|h)$')
+    if [ -n "${changed_files}" ]; then
+        cpplint --quiet --filter=-,+whitespace/line_length --linelength=100 ${changed_files} ||
+        if [ "$?" ]; then
+            exit 1
+        fi
+    fi
+
+    echo "Line-length check passed"
+}
+
+run_clang_format_diff && \
+run_line_length_check

--- a/esl/strings.h
+++ b/esl/strings.h
@@ -340,7 +340,6 @@ inline void trim_right_inplace(std::string& str, std::string_view chars) {
 
 [[nodiscard]] constexpr std::string_view trim(std::string_view str,
                                               std::string_view chars) noexcept {
-
     return trim_right(trim_left(str, chars), chars);
 }
 

--- a/tests/scope_guard_test.cpp
+++ b/tests/scope_guard_test.cpp
@@ -58,7 +58,6 @@ struct throw_on_copy_invoker {
         : invoked_counter(other.invoked_counter),
           throw_after_copied(other.throw_after_copied),
           copied_counter(other.copied_counter + 1) {
-
         if (copied_counter > throw_after_copied) {
             throw std::runtime_error("intended throw");
         }


### PR DESCRIPTION
- format options now are compliant with clang-format 17
- wrap clang-format-diff in a function
- introduce cpplint for line-length check