### PR TITLE
Use cfg file for cpplint filters

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -36,7 +36,7 @@ function run_line_length_check() {
 
     changed_files=$(git diff --cached --name-only | grep -iE '\.(cpp|h)$')
     if [ -n "${changed_files}" ]; then
-        cpplint --quiet --filter=-,+whitespace/line_length --linelength=100 ${changed_files} ||
+        cpplint --quiet ${changed_files} ||
         if [ "$?" ]; then
             exit 1
         fi

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,3 @@
+set noparent
+filter=-,+build/include_subdir,+build/include_what_you_use,+whitespace/line_length
+linelength=100

--- a/esl/detail/strings_join.h
+++ b/esl/detail/strings_join.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 namespace esl::strings::detail {
 

--- a/esl/detail/strings_match.h
+++ b/esl/detail/strings_match.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <string_view>
 

--- a/esl/detail/strings_split.h
+++ b/esl/detail/strings_split.h
@@ -9,8 +9,10 @@
 #include <iterator>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace esl::strings {


### PR DESCRIPTION
Use `CPPLINT.cfg` file to manage filters we enable.