### PR TITLE
Introduce ESL_FORCEINLINE and ignore_unused

### DIFF
--- a/esl/CMakeLists.txt
+++ b/esl/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(esl
   PRIVATE
     byteswap.h
     file_util.h
+    ignore_unused.h
     macros.h
     scope_guard.h
     strings.h

--- a/esl/detail/secure_crt.h
+++ b/esl/detail/secure_crt.h
@@ -9,13 +9,17 @@
 
 #include "esl/unique_handle.h"
 
+#if defined(_WIN32)
+#include "esl/ignore_unused.h"
+#endif
+
 namespace esl::detail {
 
 inline unique_file fopen(const std::string& filepath, const char* mode) {
 #if defined(_WIN32)
     std::FILE* fp{nullptr};
     // The global errno is set on error anyway.
-    (void)::fopen_s(&fp, filepath.c_str(), mode);
+    ignore_unused(::fopen_s(&fp, filepath.c_str(), mode));
     return wrap_unique_file(fp);
 #else
     return wrap_unique_file(std::fopen(filepath.c_str(), mode));

--- a/esl/ignore_unused.h
+++ b/esl/ignore_unused.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2024 Kingsley Chen <kingsamchen at gmail dot com>
+// This file is subject to the terms of license that can be found
+// in the LICENSE file.
+
+#pragma once
+
+#include "esl/macros.h"
+
+namespace esl {
+
+// TODO(Kingsley): Remove NOLINT once MSVC has upgraded its shipped clang-tidy.
+// See https://github.com/llvm/llvm-project/issues/87697
+template<typename... Ts>
+ESL_FORCEINLINE constexpr void
+ignore_unused(Ts&&... /*unused_vars*/) {} // NOLINT(cppcoreguidelines-missing-std-forward)
+
+template<typename... Ts>
+ESL_FORCEINLINE constexpr void ignore_unused() {}
+
+} // namespace esl

--- a/esl/macros.h
+++ b/esl/macros.h
@@ -11,3 +11,11 @@
 #define ESL_CONCAT_IMPL(a, b)  a##b
 #define ESL_CONCAT(a, b)       ESL_CONCAT_IMPL(a, b)
 #define ESL_ANONYMOUS_VAR(tag) ESL_CONCAT(ESL_CONCAT(ESL_CONCAT(tag, __LINE__), _), __COUNTER__)
+
+#if defined(_MSC_VER)
+#define ESL_FORCEINLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+#define ESL_FORCEINLINE inline __attribute__((always_inline))
+#else
+#define ESL_FORCEINLINE inline
+#endif

--- a/esl/unique_handle.h
+++ b/esl/unique_handle.h
@@ -13,6 +13,8 @@
 #include <unistd.h>
 #endif
 
+#include "esl/ignore_unused.h"
+
 namespace esl {
 
 template<typename Traits>
@@ -70,7 +72,7 @@ struct win_handle_traits {
     }
 
     static void close(handle_type handle) noexcept {
-        (void)::CloseHandle(handle);
+        ignore_unused(::CloseHandle(handle));
     }
 
     static constexpr handle_type null_handle{nullptr};
@@ -95,7 +97,7 @@ struct winfile_handle_traits {
     }
 
     static void close(handle_type handle) noexcept {
-        (void)::CloseHandle(handle);
+        ignore_unused(::CloseHandle(handle));
     }
 
     // TODO(KC): use std::bit_cast when upgrading to C++20
@@ -124,7 +126,7 @@ struct fd_traits {
     }
 
     static void close(handle_type handle) noexcept {
-        (void)::close(handle);
+        ignore_unused(::close(handle));
     }
 
     static constexpr handle_type null_handle{-1};
@@ -145,7 +147,7 @@ inline unique_fd wrap_unique_fd(int raw_fd) {
 
 struct file_deleter {
     void operator()(std::FILE* fp) const noexcept {
-        (void)std::fclose(fp);
+        ignore_unused(std::fclose(fp));
     }
 };
 

--- a/tests/scope_guard_test.cpp
+++ b/tests/scope_guard_test.cpp
@@ -12,6 +12,7 @@
 
 #include "doctest/doctest.h"
 
+#include "esl/ignore_unused.h"
 #include "esl/scope_guard.h"
 
 using esl::make_scope_guard;
@@ -73,7 +74,7 @@ TEST_SUITE_BEGIN("scope_guard");
 
 TEST_CASE("non-copyable, non-move-assignable but move-constructible") {
     auto fn = [] {
-        (void)0;
+        esl::ignore_unused(0);
     };
     using fn_t = decltype(fn);
     REQUIRE(std::is_copy_constructible_v<fn_t>);

--- a/tests/strings_join_test.cpp
+++ b/tests/strings_join_test.cpp
@@ -18,6 +18,7 @@
 #include "doctest/doctest.h"
 
 #include "esl/detail/strings_join.h"
+#include "esl/ignore_unused.h"
 #include "esl/strings.h"
 
 namespace strings = esl::strings;
@@ -26,12 +27,12 @@ namespace strings_test {
 
 struct sizable_foo {
     [[nodiscard]] std::size_t size() const noexcept {
-        (void)this;
+        esl::ignore_unused(this);
         return 0;
     }
 
     [[nodiscard]] const char* data() const noexcept {
-        (void)this;
+        esl::ignore_unused(this);
         return nullptr;
     }
 };

--- a/tests/strings_split_test.cpp
+++ b/tests/strings_split_test.cpp
@@ -24,7 +24,9 @@
 #include "doctest/doctest.h"
 
 #include "esl/detail/strings_split.h"
+#include "esl/ignore_unused.h"
 #include "esl/strings.h"
+
 #include "tests/stringification.h"
 
 namespace detail = esl::strings::detail;
@@ -34,13 +36,13 @@ namespace {
 
 struct dummy_delimiter {
     [[nodiscard]] std::size_t size() const noexcept {
-        (void)this;
+        esl::ignore_unused(this);
         return 0;
     }
 
     [[nodiscard]] std::size_t find(std::string_view /*unused*/,
                                    std::size_t /*unused*/) const noexcept {
-        (void)this;
+        esl::ignore_unused(this);
         return std::string_view::npos;
     }
 };


### PR DESCRIPTION
Use `ignore_unused` to replace old conventional `(void)` for better readability; also `ignore_unused` supports suppress on unused types/defs.