### PR TITLE
Set doctest CMAKE_POLICY_VERSION_MINIMUM

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
+  set(CMAKE_POLICY_VERSION_MINIMUM "3.5")
+endif()
+
 CPMAddPackage("gh:onqtam/doctest#v2.4.11")
 
 add_executable(esl_test)


### PR DESCRIPTION
To resolve doctest `cmake_minimum_version` failure in CMake v4, and seems doctest will not update its minimum version due to possibly breaking downstream users.

See https://github.com/doctest/doctest/issues/893